### PR TITLE
Fix for the new pandas release (v0.25.0)

### DIFF
--- a/prometheus_api_client/metric.py
+++ b/prometheus_api_client/metric.py
@@ -64,7 +64,7 @@ class Metric:
                 metric["values"] = [metric["value"]]
 
             self.metric_values = pandas.DataFrame(metric["values"], columns=["ds", "y"]).apply(
-                pandas.to_numeric, args=({"errors": "coerce"})
+                pandas.to_numeric, errors="raise"
             )
             self.metric_values["ds"] = pandas.to_datetime(self.metric_values["ds"], unit="s")
 


### PR DESCRIPTION
When converting json to a pandas df, it should raise errors when an exception is raised while converting strings to numbers instead of just ignoring them. This was updated in pandas v0.25.0

closes #24 