### PR TITLE
No strings for datetime input for Metric class constructor

### DIFF
--- a/prometheus_api_client/utils.py
+++ b/prometheus_api_client/utils.py
@@ -1,0 +1,21 @@
+"""
+Some helpful functions used in the API
+"""
+import dateparser
+
+
+def parse_datetime(date_string: str, settings: dict = None):
+    """
+    A wrapper for dateparser.parse, but the default settings are set
+    to {"DATE_ORDER": "YMD"}
+    """
+
+    settings = settings or {"DATE_ORDER": "YMD"}
+    return dateparser.parse(str(date_string), settings=settings)
+
+
+def parse_timedelta(time_a: str = "now", time_b: str = "1d"):
+    """
+    returns timedelta for time_a - time_b
+    """
+    return parse_datetime(time_a) - parse_datetime(time_b)

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -75,6 +75,37 @@ class TestMetric(unittest.TestCase):
             "Incorrect End time after addition",
         )
 
+    def test_oldest_data_datetime_with_datetime(self):
+        with self.assertRaises(TypeError, msg="incorrect parameter type accepted"):
+            _ = Metric(self.raw_metrics_list[0][0], oldest_data_datetime="2d")
+
+        expected_start_time = Metric(self.raw_metrics_list[0][0]).metric_values.iloc[4, 0]
+        new_metric = Metric(
+            self.raw_metrics_list[0][0], oldest_data_datetime=expected_start_time
+        ) + Metric(self.raw_metrics_list[1][0])
+
+        self.assertEqual(
+            expected_start_time, new_metric.start_time, "Incorrect Start time after addition"
+        )
+        self.assertEqual(
+            expected_start_time,
+            new_metric.metric_values.iloc[0, 0],
+            "Incorrect Start time after addition (in df)",
+        )
+
+    def test_oldest_data_datetime_with_timedelta(self):
+        expected_start_time = Metric(self.raw_metrics_list[0][0]).metric_values.iloc[4, 0]
+        time_delta = (
+            Metric(self.raw_metrics_list[1][0]).metric_values.iloc[-1, 0]
+            - Metric(self.raw_metrics_list[0][0]).metric_values.iloc[4, 0]
+        )
+        new_metric = Metric(self.raw_metrics_list[0][0], oldest_data_datetime=time_delta) + Metric(
+            self.raw_metrics_list[1][0]
+        )
+        self.assertEqual(
+            expected_start_time, new_metric.start_time, "Incorrect Start time after addition"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
For `oldest_data_datetime` parameter, the only accepted input types are 
`datetime.datetime`/`datetime.timedelta` or `NoneType`
Added some unit tests to check if the `oldest_data_datetime` parameter works.
Also added some useful functions in utils.py that can be used to parse datetime and timedelta objects from a string.