### PR TITLE
Remove matplotlib warning

### DIFF
--- a/prometheus_api_client/metric.py
+++ b/prometheus_api_client/metric.py
@@ -13,7 +13,6 @@ try:
     _MPL_FOUND = True
 except ImportError as exce:
     _MPL_FOUND = False
-    print("WARNING: Plotting will not work as matplotlib was not found")
 
 
 class Metric:


### PR DESCRIPTION
This warning gets printed every time any piece of the package is imported, even pieces unrelated to plotting. Since the code already throws an ImportError if `plot()` is used without matplotlib being installed, I don't think the warning is necessary.