### PR TITLE
Replace Exception rising in PrometheusConnect class to internal one

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+httmock = "*"
 
 [packages]
 retrying = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b87cc935f816f33a6a89bd308a8cab1742c5e383be2b8ebf3f180c87c9c20ad5"
+            "sha256": "0d118d7539d5d881e9e25d872bfa0adba7454e42cfde9512b5075cf388949963"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -244,5 +244,49 @@
             "version": "==1.25.8"
         }
     },
-    "develop": {}
+    "develop": {
+        "certifi": {
+            "hashes": [
+                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
+                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
+            ],
+            "version": "==2019.11.28"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "httmock": {
+            "hashes": [
+                "sha256:e0bbaced224426bcd994a5f1c64ab60e0c923ea615825c53e6c0190b2a7341fe"
+            ],
+            "index": "pypi",
+            "version": "==1.3.0"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+            ],
+            "index": "pypi",
+            "version": "==2.22.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
+                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
+            ],
+            "version": "==1.25.8"
+        }
+    }
 }

--- a/docs/source/prometheus_api_client.rst
+++ b/docs/source/prometheus_api_client.rst
@@ -29,6 +29,13 @@ prometheus\_api\_client.prometheus\_connect module
    :undoc-members:
    :show-inheritance:
 
+prometheus\_api\_client.exceptions module
+--------------------------------------------------
+
+.. automodule:: prometheus_api_client.exceptions
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Module contents
 ---------------

--- a/prometheus_api_client/exceptions.py
+++ b/prometheus_api_client/exceptions.py
@@ -1,0 +1,7 @@
+"""Project wide exception classes."""
+
+
+class PrometheusApiClientException(Exception):
+    """API client exception, raises when response status code != 200."""
+
+    pass

--- a/prometheus_api_client/prometheus_connect.py
+++ b/prometheus_api_client/prometheus_connect.py
@@ -51,7 +51,9 @@ class PrometheusConnect:
             sent along with the API request, such as "time"
         :returns: (list) A list of names of all the metrics available from the
             specified prometheus host
-        :raises: (Http Response error) Raises an exception in case of a connection error
+        :raises:
+            (RequestException) Raises an exception in case of a connection error
+            (PrometheusApiClientException) Raises in case of non 200 response status code
         """
         params = params or {}
         response = requests.get(
@@ -64,7 +66,7 @@ class PrometheusConnect:
         if response.status_code == 200:
             self._all_metrics = response.json()["data"]
         else:
-            raise Exception(
+            raise PrometheusApiClientException(
                 "HTTP Status Code {} ({})".format(response.status_code, response.content)
             )
         return self._all_metrics
@@ -82,7 +84,9 @@ class PrometheusConnect:
         :param params: (dict) Optional dictionary containing GET parameters to be sent
             along with the API request, such as "time"
         :returns: (list) A list of current metric values for the specified metric
-        :raises: (Http Response error) Raises an exception in case of a connection error
+        :raises:
+            (RequestException) Raises an exception in case of a connection error
+            (PrometheusApiClientException) Raises in case of non 200 response status code
 
         Example Usage:
             ``prom = PrometheusConnect()``
@@ -143,7 +147,10 @@ class PrometheusConnect:
             sent along with the API request, such as "time"
         :return: (list) A list of metric data for the specified metric in the given time
             range
-        :raises: (Exception) Raises an exception in case of a connection error
+        :raises:
+            (RequestException) Raises an exception in case of a connection error
+            (PrometheusApiClientException) Raises in case of non 200 response status code
+
         """
         params = params or {}
         data = []
@@ -275,7 +282,9 @@ class PrometheusConnect:
         :param params: (dict) Optional dictionary containing GET parameters to be
             sent along with the API request, such as "time"
         :returns: (list) A list of metric data received in response of the query sent
-        :raises: (Exception) Raises an exception in case of a connection error
+        :raises:
+            (RequestException) Raises an exception in case of a connection error
+            (PrometheusApiClientException) Raises in case of non 200 response status code
         """
         params = params or {}
         data = None
@@ -312,7 +321,9 @@ class PrometheusConnect:
         :param params: (dict) Optional dictionary containing GET parameters to be
             sent along with the API request, such as "timeout"
         :returns: (dict) A dict of metric data received in response of the query sent
-        :raises: (Exception) Raises an exception in case of a connection error
+        :raises:
+            (RequestException) Raises an exception in case of a connection error
+            (PrometheusApiClientException) Raises in case of non 200 response status code
         """
         start = round(start_time.timestamp())
         end = round(end_time.timestamp())

--- a/prometheus_api_client/prometheus_connect.py
+++ b/prometheus_api_client/prometheus_connect.py
@@ -9,6 +9,9 @@ from datetime import datetime, timedelta
 import requests
 from retrying import retry
 
+from .exceptions import PrometheusApiClientException
+
+
 # set up logging
 _LOGGER = logging.getLogger(__name__)
 
@@ -107,7 +110,7 @@ class PrometheusConnect:
         if response.status_code == 200:
             data += response.json()["data"]["result"]
         else:
-            raise Exception(
+            raise PrometheusApiClientException(
                 "HTTP Status Code {} ({})".format(response.status_code, response.content)
             )
         return data
@@ -191,7 +194,7 @@ class PrometheusConnect:
             if response.status_code == 200:
                 data += response.json()["data"]["result"]
             else:
-                raise Exception(
+                raise PrometheusApiClientException(
                     "HTTP Status Code {} ({})".format(response.status_code, response.content)
                 )
             if store_locally:
@@ -287,7 +290,7 @@ class PrometheusConnect:
         if response.status_code == 200:
             data = response.json()["data"]["result"]
         else:
-            raise Exception(
+            raise PrometheusApiClientException(
                 "HTTP Status Code {} ({})".format(response.status_code, response.content)
             )
 
@@ -330,7 +333,7 @@ class PrometheusConnect:
         if response.status_code == 200:
             data = response.json()["data"]["result"]
         else:
-            raise Exception(
+            raise PrometheusApiClientException(
                 "HTTP Status Code {} ({})".format(response.status_code, response.content)
             )
 

--- a/tests/mocked_network.py
+++ b/tests/mocked_network.py
@@ -1,0 +1,62 @@
+from urllib.parse import urlparse
+
+from unittest import TestCase
+
+from httmock import HTTMock, all_requests, response, urlmatch
+
+
+def mock_response(
+        content, url=None, path='', headers=None, response_url=None, status_code=200, cookies=None, func=None
+):
+    """Universal handler for specify mocks inplace"""
+    if func is None:
+
+        def mocked(url, request):
+            mock = response(
+                status_code=status_code, content=content, request=request, headers=headers
+            )
+            if cookies:
+                mock.cookies = cookies
+            mock.url = response_url if response_url else url
+            return mock
+
+    else:
+        mocked = func
+
+    if url:
+        parsed = urlparse(url)
+        return urlmatch(netloc=parsed.netloc, path=parsed.path)(func=mocked)
+    elif path:
+        return urlmatch(path=path)(func=mocked)
+    else:
+        return all_requests(func=mocked)
+
+
+class ResponseMock(HTTMock):
+    called = False
+    call_count = 0
+
+    def intercept(self, request, **kwargs):
+        resp = super(ResponseMock, self).intercept(request, **kwargs)
+        if resp is not None and self.log_requests:
+            self.called = True
+            self.call_count += 1
+            self.requests.append(request)
+        return resp
+
+    def __init__(self, *args, log_requests=True, **kwargs):
+        handler = mock_response(*args, **kwargs)
+        self.log_requests = log_requests
+        self.requests = []
+        super().__init__(handler)
+
+
+class BaseMockedNetworkTestcase(TestCase):
+
+    def run(self, *args, **kwargs):
+        with ResponseMock('BOOM!', status_code=403):
+            return super().run(*args, **kwargs)
+
+    @property
+    def mock_response(self):
+        return ResponseMock

--- a/tests/mocked_network.py
+++ b/tests/mocked_network.py
@@ -44,7 +44,8 @@ class ResponseMock(HTTMock):
             self.requests.append(request)
         return resp
 
-    def __init__(self, *args, log_requests=True, **kwargs):
+    def __init__(self, *args, **kwargs):
+        log_requests = kwargs.pop('log_requests', True)
         handler = mock_response(*args, **kwargs)
         self.log_requests = log_requests
         self.requests = []
@@ -53,9 +54,9 @@ class ResponseMock(HTTMock):
 
 class BaseMockedNetworkTestcase(TestCase):
 
-    def run(self, *args, **kwargs):
+    def run(self, result=None):
         with ResponseMock('BOOM!', status_code=403):
-            return super().run(*args, **kwargs)
+            return super().run(result)
 
     @property
     def mock_response(self):


### PR DESCRIPTION
Hi,
I suggest to replace `Exception` rising in `PrometheusConnect` to internal exception class.
Due to this changes errors handling in end-users code will be bit more obvious :)

`PrometheusApiClientException` inherited from `Exception`, so no breaking changes there

Thanks,
Denis