### PR TITLE
Mocks for tests

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -1,21 +1,28 @@
 [all]
 bears = LineCountBear, FilenameBear
 files = **.py, **.yml, **.rst, **.md
-ignore = **/__pycache__/**, **/__pycache__, __pycache__, __pycache__/**, **/*.pyc, *.pyc
+ignore = **/__pycache__/**, **/__pycache__, __pycache__, __pycache__/**, **/*.pyc, *.pyc, .tox/**, .pytest_cache/**
 max_lines_per_file = 1000
 max_line_length = 120
 
-[all.python]
-bears = PycodestyleBear, PyDocStyleBear
+[all.python.codestyle]
+bears = PycodestyleBear
 files = **.py
 language = Python
 editor = vim
-ignore = setup.py, docs/*, tests/*
+ignore = setup.py, docs/**, .tox/**, .eggs/**
+
+[all.python.docstyle]
+bears = PyDocStyleBear
+files = **.py
+language = Python
+editor = vim
+ignore = setup.py, docs/**, tests/**, .tox/**, .eggs/**
 
 [all.yaml]
 bears = YAMLLintBear
 files = **.yaml, **.yml
-ignore = .zuul.yaml
+ignore = .zuul.yaml, .tox/**
 max_line_length = 120
 
 [zuul.yaml]

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,2 @@
+exclude_paths:
+  - '**/tests/unit/**'

--- a/docs/source/prometheus_api_client.rst
+++ b/docs/source/prometheus_api_client.rst
@@ -29,6 +29,13 @@ prometheus\_api\_client.prometheus\_connect module
    :undoc-members:
    :show-inheritance:
 
+prometheus\_api\_client.exceptions module
+--------------------------------------------------
+
+.. automodule:: prometheus_api_client.exceptions
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Module contents
 ---------------

--- a/prometheus_api_client/exceptions.py
+++ b/prometheus_api_client/exceptions.py
@@ -1,0 +1,7 @@
+"""Project wide exception classes."""
+
+
+class PrometheusApiClientException(Exception):
+    """API client exception, raises when response status code != 200."""
+
+    pass

--- a/prometheus_api_client/prometheus_connect.py
+++ b/prometheus_api_client/prometheus_connect.py
@@ -51,7 +51,9 @@ class PrometheusConnect:
             sent along with the API request, such as "time"
         :returns: (list) A list of names of all the metrics available from the
             specified prometheus host
-        :raises: (Http Response error) Raises an exception in case of a connection error
+        :raises:
+            (RequestException) Raises an exception in case of a connection error
+            (PrometheusApiClientException) Raises in case of non 200 response status code
         """
         params = params or {}
         response = requests.get(
@@ -64,7 +66,7 @@ class PrometheusConnect:
         if response.status_code == 200:
             self._all_metrics = response.json()["data"]
         else:
-            raise Exception(
+            raise PrometheusApiClientException(
                 "HTTP Status Code {} ({})".format(response.status_code, response.content)
             )
         return self._all_metrics
@@ -82,7 +84,9 @@ class PrometheusConnect:
         :param params: (dict) Optional dictionary containing GET parameters to be sent
             along with the API request, such as "time"
         :returns: (list) A list of current metric values for the specified metric
-        :raises: (Http Response error) Raises an exception in case of a connection error
+        :raises:
+            (RequestException) Raises an exception in case of a connection error
+            (PrometheusApiClientException) Raises in case of non 200 response status code
 
         Example Usage:
             ``prom = PrometheusConnect()``
@@ -143,7 +147,10 @@ class PrometheusConnect:
             sent along with the API request, such as "time"
         :return: (list) A list of metric data for the specified metric in the given time
             range
-        :raises: (Exception) Raises an exception in case of a connection error
+        :raises:
+            (RequestException) Raises an exception in case of a connection error
+            (PrometheusApiClientException) Raises in case of non 200 response status code
+
         """
         params = params or {}
         data = []
@@ -275,7 +282,9 @@ class PrometheusConnect:
         :param params: (dict) Optional dictionary containing GET parameters to be
             sent along with the API request, such as "time"
         :returns: (list) A list of metric data received in response of the query sent
-        :raises: (Exception) Raises an exception in case of a connection error
+        :raises:
+            (RequestException) Raises an exception in case of a connection error
+            (PrometheusApiClientException) Raises in case of non 200 response status code
         """
         params = params or {}
         data = None
@@ -312,7 +321,9 @@ class PrometheusConnect:
         :param params: (dict) Optional dictionary containing GET parameters to be
             sent along with the API request, such as "timeout"
         :returns: (dict) A dict of metric data received in response of the query sent
-        :raises: (Exception) Raises an exception in case of a connection error
+        :raises:
+            (RequestException) Raises an exception in case of a connection error
+            (PrometheusApiClientException) Raises in case of non 200 response status code
         """
         start = round(start_time.timestamp())
         end = round(end_time.timestamp())

--- a/prometheus_api_client/prometheus_connect.py
+++ b/prometheus_api_client/prometheus_connect.py
@@ -9,6 +9,9 @@ from datetime import datetime, timedelta
 import requests
 from retrying import retry
 
+from .exceptions import PrometheusApiClientException
+
+
 # set up logging
 _LOGGER = logging.getLogger(__name__)
 
@@ -107,7 +110,7 @@ class PrometheusConnect:
         if response.status_code == 200:
             data += response.json()["data"]["result"]
         else:
-            raise Exception(
+            raise PrometheusApiClientException(
                 "HTTP Status Code {} ({})".format(response.status_code, response.content)
             )
         return data
@@ -191,7 +194,7 @@ class PrometheusConnect:
             if response.status_code == 200:
                 data += response.json()["data"]["result"]
             else:
-                raise Exception(
+                raise PrometheusApiClientException(
                     "HTTP Status Code {} ({})".format(response.status_code, response.content)
                 )
             if store_locally:
@@ -287,7 +290,7 @@ class PrometheusConnect:
         if response.status_code == 200:
             data = response.json()["data"]["result"]
         else:
-            raise Exception(
+            raise PrometheusApiClientException(
                 "HTTP Status Code {} ({})".format(response.status_code, response.content)
             )
 
@@ -330,7 +333,7 @@ class PrometheusConnect:
         if response.status_code == 200:
             data = response.json()["data"]["result"]
         else:
-            raise Exception(
+            raise PrometheusApiClientException(
                 "HTTP Status Code {} ({})".format(response.status_code, response.content)
             )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+MARKERS = [
+    "e2e: tests that communicates with external services, such as Prometheus",
+]
+
+
+def pytest_configure(config):
+    # register an additional markers
+    for markerline in MARKERS:
+        config.addinivalue_line("markers", markerline)

--- a/tests/test_prometheus_connect.py
+++ b/tests/test_prometheus_connect.py
@@ -84,21 +84,3 @@ class TestPrometheusConnect(unittest.TestCase):
             < metric_objects_list[0].end_time.timestamp(),
             "invalid metric end time (with given chunk_size)",
         )
-
-    def test_get_metric_range_data_with_incorrect_input_types(self):
-        start_time = datetime.now() - timedelta(minutes=20)
-        chunk_size = timedelta(minutes=7)
-        end_time = datetime.now() - timedelta(minutes=10)
-
-        with self.assertRaises(TypeError, msg="start_time accepted invalid value type"):
-            _ = self.pc.get_metric_range_data(
-                metric_name="up", start_time="20m", end_time=end_time, chunk_size=chunk_size
-            )
-        with self.assertRaises(TypeError, msg="end_time accepted invalid value type"):
-            _ = self.pc.get_metric_range_data(
-                metric_name="up", start_time=start_time, end_time="10m", chunk_size=chunk_size
-            )
-        with self.assertRaises(TypeError, msg="chunk_size accepted invalid value type"):
-            _ = self.pc.get_metric_range_data(
-                metric_name="up", start_time=start_time, end_time=end_time, chunk_size="10m"
-            )

--- a/tests/test_prometheus_connect.py
+++ b/tests/test_prometheus_connect.py
@@ -2,11 +2,13 @@
 Test module for class PrometheusConnect
 """
 import unittest
+import pytest
 import os
 from datetime import datetime, timedelta
 from prometheus_api_client import MetricsList, PrometheusConnect
 
 
+@pytest.mark.e2e
 class TestPrometheusConnect(unittest.TestCase):
     """
     Test module for class PrometheusConnect

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,66 @@
+from urllib.parse import urlparse
+
+import pytest
+
+from httmock import HTTMock, all_requests, response, urlmatch
+
+
+def mock_response(
+        content, url=None, path='', headers=None, response_url=None, status_code=200, cookies=None, func=None
+):
+    """Universal handler for specify mocks inplace"""
+    if func is None:
+
+        def mocked(url, request):
+            mock = response(
+                status_code=status_code, content=content, request=request, headers=headers
+            )
+            if cookies:
+                mock.cookies = cookies
+            mock.url = response_url if response_url else url
+            return mock
+
+    else:
+        mocked = func
+
+    if url:
+        parsed = urlparse(url)
+        return urlmatch(netloc=parsed.netloc, path=parsed.path)(func=mocked)
+    elif path:
+        return urlmatch(path=path)(func=mocked)
+    else:
+        return all_requests(func=mocked)
+
+
+class ResponseMock(HTTMock):
+    called = False
+    call_count = 0
+
+    def intercept(self, request, **kwargs):
+        resp = super(ResponseMock, self).intercept(request, **kwargs)
+        if resp and self.log_requests:
+            self.called = True
+            self.call_count += 1
+            self.requests.append(request)
+        return resp
+
+    def __init__(self, *args, log_requests=True, **kwargs):
+        handler = mock_response(*args, **kwargs)
+        self.log_requests = log_requests
+        self.requests = []
+        super().__init__(handler)
+
+
+@pytest.fixture
+def mocked_response():
+    return ResponseMock
+
+
+@pytest.fixture(scope="module", autouse=True)
+def block_network():
+    """
+    Block all network connections for unittests
+    """
+
+    with ResponseMock("BOOM!", status_code=403):
+        yield

--- a/tests/unit/prom_responses.py
+++ b/tests/unit/prom_responses.py
@@ -1,0 +1,1 @@
+ALL_METRICS = {"status": "success", "data": ["up", "alerts"]}

--- a/tests/unit/test_prometheus_connect.py
+++ b/tests/unit/test_prometheus_connect.py
@@ -1,0 +1,76 @@
+from datetime import datetime, timedelta
+
+import pytest
+import requests
+
+from prometheus_api_client.prometheus_connect import PrometheusConnect
+from prometheus_api_client.exceptions import PrometheusApiClientException
+
+from .prom_responses import ALL_METRICS
+
+
+def test_network_blocked():
+    """
+    For documenting purposes, keep in mind that all network interactions blocked in this module
+    """
+    resp = requests.get("http://some-url-there.org")
+    assert resp.content == b"BOOM!"
+    assert resp.status_code == 403
+
+
+class TestPrometheusConnect:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.pc = PrometheusConnect(url="http://mocked-host.org")
+
+    def test_unauthorized(self, mocked_response):
+        with mocked_response("Unauthorized", status_code=403):
+            with pytest.raises(PrometheusApiClientException) as exc:
+                self.pc.all_metrics()
+        assert "HTTP Status Code 403 (b'Unauthorized')" in str(exc)
+
+    def test_broken_responses(self):
+        with pytest.raises(PrometheusApiClientException) as exc:
+            self.pc.all_metrics()
+        assert "HTTP Status Code 403 (b'BOOM!')" in str(exc)
+
+        with pytest.raises(PrometheusApiClientException) as exc:
+            self.pc.get_current_metric_value("metric")
+        assert "HTTP Status Code 403 (b'BOOM!')" in str(exc)
+
+        with pytest.raises(PrometheusApiClientException) as exc:
+            self.pc.get_metric_range_data("metric")
+        assert "HTTP Status Code 403 (b'BOOM!')" in str(exc)
+
+        with pytest.raises(PrometheusApiClientException) as exc:
+            self.pc.custom_query_range("query", datetime.now(), datetime.now(), "1")
+        assert "HTTP Status Code 403 (b'BOOM!')" in str(exc)
+
+        with pytest.raises(PrometheusApiClientException) as exc:
+            self.pc.custom_query("query")
+        assert "HTTP Status Code 403 (b'BOOM!')" in str(exc)
+
+    def test_all_metrics(self, mocked_response):
+        with mocked_response(ALL_METRICS) as handler:
+            assert len(self.pc.all_metrics())
+            assert handler.call_count == 1
+            request = handler.requests[0]
+            assert request.path_url == "/api/v1/label/__name__/values"
+
+    def test_get_metric_range_data_with_incorrect_input_types(self):
+        start_time = datetime.now() - timedelta(minutes=20)
+        chunk_size = timedelta(minutes=7)
+        end_time = datetime.now() - timedelta(minutes=10)
+
+        with pytest.raises(TypeError):
+            self.pc.get_metric_range_data(
+                metric_name="up", start_time="20m", end_time=end_time, chunk_size=chunk_size
+            )
+        with pytest.raises(TypeError):
+            self.pc.get_metric_range_data(
+                metric_name="up", start_time=start_time, end_time="10m", chunk_size=chunk_size
+            )
+        with pytest.raises(TypeError):
+            self.pc.get_metric_range_data(
+                metric_name="up", start_time=start_time, end_time=end_time, chunk_size="10m"
+            )


### PR DESCRIPTION
Changes from #72, fixtures/helpers for mocking network and initial structure for separating unittests.

Requires [httmock](https://github.com/patrys/httmock) library.
