### PR TITLE
switched to custom_query_range for get_aggregation

### DIFF
--- a/tests/test_prometheus_connect.py
+++ b/tests/test_prometheus_connect.py
@@ -103,7 +103,12 @@ class TestPrometheusConnect(unittest.TestCase):
 
     def test_get_metric_aggregation(self):  # noqa D102
         operations = ["sum", "max", "min", "variance", "percentile_50", "deviation", "average"]
-        aggregated_values = self.pc.get_metric_aggregation(query="up", operations=operations)
+        start_time = datetime.now() - timedelta(minutes=10)
+        end_time = datetime.now()
+        step = "15"
+        aggregated_values = self.pc.get_metric_aggregation(
+            query="up", operations=operations, start_time=start_time, end_time=end_time, step=step
+        )
 
         self.assertTrue(len(aggregated_values) > 0, "no values received after aggregating")
 
@@ -169,7 +174,11 @@ class TestPrometheusConnectWithMockedNetwork(BaseMockedNetworkTestcase):
         self.assertEqual("HTTP Status Code 403 (b'BOOM!')", str(exc.exception))
 
         with self.assertRaises(PrometheusApiClientException) as exc:
-            self.pc.get_metric_aggregation("query", ["sum", "deviation"])
+            start_time = datetime.now() - timedelta(minutes=10)
+            end_time = datetime.now()
+            self.pc.get_metric_aggregation(
+                "query", ["sum", "deviation"], start_time, end_time, "15"
+            )
         self.assertEqual("HTTP Status Code 403 (b'BOOM!')", str(exc.exception))
 
     def test_all_metrics_method(self):  # noqa D102


### PR DESCRIPTION
Previously, get_aggregation method used to call custom_query method inside to get the results for a query.

In the recent use cases, it is becoming difficult to pass the start time and end time along with other parameters. We already have an existing function custom_query_range which takes start_time and end_time as a argument.

Replacing the custom_query with custom_query_range, this will help in using get_aggregations method in more cases.

Also, when do you guys plan to roll-out the next release of update in pip version with latest code? This will help us in using the new methods in existing tools :) 