### PR TITLE
update pytest prom url since operatefirst url is now behind a proxy

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -3,6 +3,6 @@ check:
   - thoth-pytest
   - thoth-precommit
 pytest-env:
-  PROM_URL: "http://prometheus-portal-opf-monitoring.apps.zero.massopen.cloud/"
+  PROM_URL: "http://demo.robustperception.io:9090/"
 release:
   - upload-pypi-sesheta

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ For more functions included in the `prometheus-api-client` library, please refer
 
 ## Running tests
 
-`PROM_URL="http://prometheus-route-aiops-prod-prometheus-predict.cloud.paas.psi.redhat.com/" pytest`
+`PROM_URL="http://demo.robustperception.io:9090/" pytest`
 
 ## Code Styling and Linting
 


### PR DESCRIPTION
this will fix issues with pytest ci in #209 

cc @harshad16 