### PR TITLE
Ensuring Metric Values are Cast to Float when they are Strings

### DIFF
--- a/prometheus_api_client/exceptions.py
+++ b/prometheus_api_client/exceptions.py
@@ -7,7 +7,7 @@ class PrometheusApiClientException(Exception):
     pass
 
 
-class MetricValueConversionFailed(Exception):
+class MetricValueConversionError(Exception):
     """Raises when we find a metric that is a string where we fail to convert it to a float."""
 
     pass

--- a/prometheus_api_client/exceptions.py
+++ b/prometheus_api_client/exceptions.py
@@ -5,3 +5,9 @@ class PrometheusApiClientException(Exception):
     """API client exception, raises when response status code != 200."""
 
     pass
+
+
+class MetricValueConversionFailed(Exception):
+    """Raises when we find a metric that is a string where we fail to convert it to a float."""
+
+    pass

--- a/prometheus_api_client/metric.py
+++ b/prometheus_api_client/metric.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 import datetime
 import pandas
 
-from prometheus_api_client.exceptions import MetricValueConversionFailed
+from prometheus_api_client.exceptions import MetricValueConversionError
 
 try:
     import matplotlib.pyplot as plt
@@ -77,7 +77,7 @@ class Metric:
                     try:
                         metric_value = float(metric_value)
                     except TypeError:
-                        raise MetricValueConversionFailed(
+                        raise MetricValueConversionError(
                             "Converting string metric value to float failed."
                         )
                 metric["values"] = [[datestamp, metric_value]]

--- a/prometheus_api_client/metric.py
+++ b/prometheus_api_client/metric.py
@@ -3,6 +3,8 @@ from copy import deepcopy
 import datetime
 import pandas
 
+from prometheus_api_client.exceptions import MetricValueConversionFailed
+
 try:
     import matplotlib.pyplot as plt
     from pandas.plotting import register_matplotlib_converters
@@ -45,7 +47,7 @@ class Metric:
 
     """
 
-    def __init__(self, metric, oldest_data_datetime=None):
+    def __init__(self, metric, oldest_data_datetime=None, value_as_type=float):
         """Functions as a Constructor for the Metric object."""
         if not isinstance(
             oldest_data_datetime, (datetime.datetime, datetime.timedelta, type(None))
@@ -69,7 +71,16 @@ class Metric:
 
             # if it is a single value metric change key name
             if "value" in metric:
-                metric["values"] = [metric["value"]]
+                datestamp = metric["value"][0]
+                metric_value = metric["value"][1]
+                if isinstance(metric_value, str):
+                    try:
+                        metric_value = float(metric_value)
+                    except TypeError:
+                        raise MetricValueConversionFailed(
+                            "Converting string metric value to float failed."
+                        )
+                metric["values"] = [[datestamp, metric_value]]
 
             self.metric_values = pandas.DataFrame(metric["values"], columns=["ds", "y"]).apply(
                 pandas.to_numeric, errors="raise"

--- a/prometheus_api_client/metric.py
+++ b/prometheus_api_client/metric.py
@@ -47,7 +47,7 @@ class Metric:
 
     """
 
-    def __init__(self, metric, oldest_data_datetime=None, value_as_type=float):
+    def __init__(self, metric, oldest_data_datetime=None):
         """Functions as a Constructor for the Metric object."""
         if not isinstance(
             oldest_data_datetime, (datetime.datetime, datetime.timedelta, type(None))

--- a/prometheus_api_client/metric.py
+++ b/prometheus_api_client/metric.py
@@ -76,7 +76,7 @@ class Metric:
                 if isinstance(metric_value, str):
                     try:
                         metric_value = float(metric_value)
-                    except TypeError:
+                    except (TypeError, ValueError):
                         raise MetricValueConversionError(
                             "Converting string metric value to float failed."
                         )

--- a/prometheus_api_client/metric_range_df.py
+++ b/prometheus_api_client/metric_range_df.py
@@ -73,7 +73,7 @@ class MetricRangeDataFrame(DataFrame):
                 if isinstance(metric_value, str):
                     try:
                         metric_value = float(metric_value)
-                    except TypeError:
+                    except (TypeError, ValueError):
                         raise MetricValueConversionError(
                             "Converting string metric value to float failed."
                         )

--- a/prometheus_api_client/metric_range_df.py
+++ b/prometheus_api_client/metric_range_df.py
@@ -3,7 +3,7 @@ from pandas import DataFrame
 from pandas._typing import Axes, Dtype
 from typing import Optional, Sequence
 
-from prometheus_api_client.exceptions import MetricValueConversionFailed
+from prometheus_api_client.exceptions import MetricValueConversionError
 
 
 class MetricRangeDataFrame(DataFrame):
@@ -74,7 +74,7 @@ class MetricRangeDataFrame(DataFrame):
                     try:
                         metric_value = float(metric_value)
                     except TypeError:
-                        raise MetricValueConversionFailed(
+                        raise MetricValueConversionError(
                             "Converting string metric value to float failed."
                         )
                 row_data.append({**v["metric"], "timestamp": t[0], "value": metric_value})

--- a/prometheus_api_client/metric_snapshot_df.py
+++ b/prometheus_api_client/metric_snapshot_df.py
@@ -82,4 +82,4 @@ class MetricSnapshotDataFrame(DataFrame):
     @staticmethod
     def _get_nth_ts_value_pair(i: dict, n: int):
         val = i["values"][n] if "values" in i else i["value"]
-        return {"timestamp": val[0], "value": val[1]}
+        return {"timestamp": val[0], "value": float(val[1])}

--- a/prometheus_api_client/metric_snapshot_df.py
+++ b/prometheus_api_client/metric_snapshot_df.py
@@ -3,7 +3,7 @@ from pandas import DataFrame
 from pandas._typing import Axes, Dtype
 from typing import Optional, Sequence
 
-from prometheus_api_client.exceptions import MetricValueConversionFailed
+from prometheus_api_client.exceptions import MetricValueConversionError
 
 
 class MetricSnapshotDataFrame(DataFrame):
@@ -89,5 +89,5 @@ class MetricSnapshotDataFrame(DataFrame):
             try:
                 value = float(value)
             except TypeError:
-                raise MetricValueConversionFailed("Converting string metric value to float failed.")
+                raise MetricValueConversionError("Converting string metric value to float failed.")
         return {"timestamp": val[0], "value": value}

--- a/prometheus_api_client/metric_snapshot_df.py
+++ b/prometheus_api_client/metric_snapshot_df.py
@@ -3,6 +3,8 @@ from pandas import DataFrame
 from pandas._typing import Axes, Dtype
 from typing import Optional, Sequence
 
+from prometheus_api_client.exceptions import MetricValueConversionFailed
+
 
 class MetricSnapshotDataFrame(DataFrame):
     """Subclass to format and represent Prometheus query response as pandas.DataFrame.
@@ -82,4 +84,10 @@ class MetricSnapshotDataFrame(DataFrame):
     @staticmethod
     def _get_nth_ts_value_pair(i: dict, n: int):
         val = i["values"][n] if "values" in i else i["value"]
-        return {"timestamp": val[0], "value": float(val[1])}
+        value = val[1]
+        if isinstance(value, str):
+            try:
+                value = float(value)
+            except TypeError:
+                raise MetricValueConversionFailed("Converting string metric value to float failed.")
+        return {"timestamp": val[0], "value": value}

--- a/prometheus_api_client/metric_snapshot_df.py
+++ b/prometheus_api_client/metric_snapshot_df.py
@@ -88,6 +88,6 @@ class MetricSnapshotDataFrame(DataFrame):
         if isinstance(value, str):
             try:
                 value = float(value)
-            except TypeError:
+            except (TypeError, ValueError):
                 raise MetricValueConversionError("Converting string metric value to float failed.")
         return {"timestamp": val[0], "value": value}

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -1,7 +1,11 @@
 """Unit tests for Metrics Class."""
 import unittest
 import datetime
+
+import pytest
+
 from prometheus_api_client import Metric
+from prometheus_api_client.exceptions import MetricValueConversionError
 from .test_with_metrics import TestWithMetrics
 
 
@@ -95,6 +99,27 @@ class TestMetric(unittest.TestCase, TestWithMetrics.Common):
         self.assertEqual(
             expected_start_time, new_metric.start_time, "Incorrect Start time after addition"
         )
+
+    def test_init_valid_string_metric_value(self):
+        """Ensures metric values provided as strings are properly cast to a numeric value (in this case, a float)."""
+        test_metric = Metric(
+            metric={
+                "metric": {"__name__": "test_metric", "fake": "data",},
+                "value": [1627485628.789, "26.82068965517243"],
+            }
+        )
+
+        self.assertTrue(isinstance(test_metric, Metric))
+
+    def test_init_invalid_string_metric_value(self):
+        """Ensures metric values provided as strings are properly cast to a numeric value (in this case, a float)."""
+        with pytest.raises(MetricValueConversionError):
+            Metric(
+                metric={
+                    "metric": {"__name__": "test_metric", "fake": "data",},
+                    "value": [1627485628.789, "26.8206896551724326.82068965517243"],
+                }
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_metric_range_df.py
+++ b/tests/test_metric_range_df.py
@@ -1,7 +1,10 @@
 """Unit Tests for MetricRangeDataFrame."""
 import unittest
 import pandas as pd
+import pytest
+
 from prometheus_api_client import MetricRangeDataFrame
+from prometheus_api_client.exceptions import MetricValueConversionError
 from .test_with_metrics import TestWithMetrics
 
 
@@ -89,6 +92,30 @@ class TestMetricRangeDataFrame(unittest.TestCase, TestWithMetrics.Common):  # no
             MetricRangeDataFrame([self.raw_metrics_list[0][0]]).shape,
             "incorrect dataframe shape when initialized with single json list",
         )
+
+    def test_init_invalid_string_value(self):
+        """Ensures metric values provided as concatenated strings are caught with a meaningful exception."""
+        with pytest.raises(MetricValueConversionError):
+            MetricRangeDataFrame(
+                {
+                    "metric": {"__name__": "test_metric", "fake": "data",},
+                    "values": [[1627485628.789, "26.8206896551724326.82068965517243"]],
+                }
+            )
+
+    def test_init_valid_string_value(self):
+        """Ensures metric values provided as a string but are valid floats are processed properly."""
+
+        results = MetricRangeDataFrame(
+                {
+                    "metric": {"__name__": "test_metric", "fake": "data",},
+                    "values": [[1627485628.789, "26.82068965517243"]],
+                }
+            )
+
+        shape = results.shape
+
+        self.assertEqual((1, 3), results.shape)
 
 
 if __name__ == "__main__":

--- a/tests/test_metric_range_df.py
+++ b/tests/test_metric_range_df.py
@@ -105,15 +105,12 @@ class TestMetricRangeDataFrame(unittest.TestCase, TestWithMetrics.Common):  # no
 
     def test_init_valid_string_value(self):
         """Ensures metric values provided as a string but are valid floats are processed properly."""
-
         results = MetricRangeDataFrame(
-                {
-                    "metric": {"__name__": "test_metric", "fake": "data",},
-                    "values": [[1627485628.789, "26.82068965517243"]],
-                }
-            )
-
-        shape = results.shape
+            {
+                "metric": {"__name__": "test_metric", "fake": "data",},
+                "values": [[1627485628.789, "26.82068965517243"]],
+            }
+        )
 
         self.assertEqual((1, 3), results.shape)
 

--- a/tests/test_metric_snapshot_df.py
+++ b/tests/test_metric_snapshot_df.py
@@ -72,6 +72,31 @@ class TestMetricSnapshotDataFrame(unittest.TestCase):  # noqa D101
             "incorrect dataframe shape when initialized with single json list",
         )
 
+    def test_init_multiple_metrics(self):
+        """
+        Tests to ensure multiple metric values provided as strings are
+        properly cast to a numeric value (in this case, a float).
+
+        """
+        raw_data = [
+            {
+                "metric": {
+                    "fake": "data",
+                },
+                "value": [1627485628.789, "26.82068965517243"],
+            },
+            {
+                "metric": {
+                    "fake": "data",
+                },
+                "value": [1627485628.789, "26.82068965517243"],
+            },
+        ]
+
+        test_df = MetricSnapshotDataFrame(data=raw_data)
+
+        self.assertTrue(isinstance(test_df["value"][0], float))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_metric_snapshot_df.py
+++ b/tests/test_metric_snapshot_df.py
@@ -2,7 +2,11 @@
 import unittest
 import json
 import os
+
+import pytest
+
 from prometheus_api_client import MetricSnapshotDataFrame
+from prometheus_api_client.exceptions import MetricValueConversionError
 
 
 class TestMetricSnapshotDataFrame(unittest.TestCase):  # noqa D101
@@ -82,6 +86,18 @@ class TestMetricSnapshotDataFrame(unittest.TestCase):  # noqa D101
         test_df = MetricSnapshotDataFrame(data=raw_data)
 
         self.assertTrue(isinstance(test_df["value"][0], float))
+
+    def test_init_invalid_float_error(self):
+        """Ensures metric values provided as strings are properly cast to a numeric value (in this case, a float)."""
+        raw_data = [
+            {
+                "metric": {"fake": "data",},
+                "value": [1627485628.789, "26.8206896551724326.82068965517243"],
+            },
+        ]
+
+        with pytest.raises(MetricValueConversionError):
+            MetricSnapshotDataFrame(data=raw_data)
 
 
 if __name__ == "__main__":

--- a/tests/test_metric_snapshot_df.py
+++ b/tests/test_metric_snapshot_df.py
@@ -73,24 +73,10 @@ class TestMetricSnapshotDataFrame(unittest.TestCase):  # noqa D101
         )
 
     def test_init_multiple_metrics(self):
-        """
-        Tests to ensure multiple metric values provided as strings are
-        properly cast to a numeric value (in this case, a float).
-
-        """
+        """Ensures metric values provided as strings are properly cast to a numeric value (in this case, a float)."""
         raw_data = [
-            {
-                "metric": {
-                    "fake": "data",
-                },
-                "value": [1627485628.789, "26.82068965517243"],
-            },
-            {
-                "metric": {
-                    "fake": "data",
-                },
-                "value": [1627485628.789, "26.82068965517243"],
-            },
+            {"metric": {"fake": "data",}, "value": [1627485628.789, "26.82068965517243"],},
+            {"metric": {"fake": "data",}, "value": [1627485628.789, "26.82068965517243"],},
         ]
 
         test_df = MetricSnapshotDataFrame(data=raw_data)


### PR DESCRIPTION
In #214 I found that some Prometheus instances will return the metric value as a string instead of a float. This causes issues when Pandas attempts to sum these metric values as it will simply concatenate the strings, which leads to a TypeError.

My proposal here is to simply attempt the data conversion internally and raise an exception when it fails. This should hopefully give a better indication to the end user that they need to check their data.

If the value is not a string, we assume everything is normal and no changes are made to the existing workflows.

An alternative to this path would be to indicate to consumers of this package that they need to clean their own data before hand, but it would sure be nice to just have the package handle this, as this appears to be something that Prometheus itself has started doing with recent releases.

## Added

- Custom exception and message when casting `str` metric value to `float`

## Changed

- `Metric`, `MetricSnapshotDataFrame`, `MetricRangeDataFrame` classes to all do `str` --> `float` conversions when metric values are found to be strings.